### PR TITLE
security issue fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ buildNumber.properties
 
 # Exclude maven wrapper
 !/.mvn/wrapper/maven-wrapper.jar
+
+#IntelliJ
+*/.idea

--- a/lambda-logging/pom.xml
+++ b/lambda-logging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.symphonia</groupId>
         <artifactId>lambda-monitoring-parent</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>lambda-logging</artifactId>

--- a/lambda-metrics-maven-plugin/pom.xml
+++ b/lambda-metrics-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.symphonia</groupId>
         <artifactId>lambda-monitoring-parent</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>lambda-metrics-maven-plugin</artifactId>

--- a/lambda-metrics/pom.xml
+++ b/lambda-metrics/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.symphonia</groupId>
         <artifactId>lambda-monitoring-parent</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>lambda-metrics</artifactId>

--- a/lambda-monitoring-sample-project/pom.xml
+++ b/lambda-monitoring-sample-project/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>lambda-monitoring-parent</artifactId>
         <groupId>io.symphonia</groupId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>lambda-monitoring-sample-project</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.symphonia</groupId>
     <artifactId>lambda-monitoring-parent</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.0.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>lambda-monitoring</name>
@@ -79,7 +79,7 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.1.8</version>
+                <version>1.2.3</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>


### PR DESCRIPTION
Bumps the`logback-classic` version to the most recent stable version `1.2.3` in response to CVE-2017-5929 exploit reported in issue #7 . This change should be completely transparent and shouldn't anyone using `lambda-monitoring` 